### PR TITLE
学术网站规则

### DIFF
--- a/实用规则片段/学术网站.txt
+++ b/实用规则片段/学术网站.txt
@@ -1,12 +1,12 @@
 [Rule]
 
-//教育机构 edu 直连
-DOMAIN-KEYWORD,edu.cn,DIRECT
+# 此规则适用于学校校园网已经购买论文网站版权，通过校园网的直连才能具备该免费下载的权限。
+# 此规则使用前应先咨询校方，是否有购买版权。若没有，此规则无用处。更适合大学生及以上学学历学生使用。
 
-//知网
+// 中国知网
 DOMAIN-KEYWORD,cnki.net,DIRECT
 
-//万方
+// 万方
 DOMAIN-KEYWORD,wanfangdata,DIRECT
 
 // 国际环境生态学术出版商
@@ -19,5 +19,5 @@ DOMAIN-SUFFIX,sciencemag.org,DIRECT
 DOMAIN-SUFFIX,jstor.org,DIRECT
 DOMAIN-SUFFIX,cabdirect.org,DIRECT
 
-//告别出版商绑架
+// 告别出版商绑架
 DOMAIN-SUFFIX,sci-hub.cc,Proxy


### PR DESCRIPTION
提供了：
ELSEVIER、researchgate、Springer、Wiley、Science 集团、jstor、cabdirect 的教育网直连；
SCI-HUB 的代理连接；
知网和万方直连；
以及国内高校、科研机构的直连。
如果公网使用校内代理，请将 DIRECT 规则，直接更改为 Proxy